### PR TITLE
feat(game-logic) modify mochigoma logic

### DIFF
--- a/src/main/java/com/souma1024/shogiv2/domain/PieceUtil.java
+++ b/src/main/java/com/souma1024/shogiv2/domain/PieceUtil.java
@@ -218,18 +218,18 @@ public class PieceUtil {
 
     private static boolean canDropAt(int[][] board, int piece, int x, int y, PlayerSide side) {
         // 二歩
-        if (isNiFu(board, x, side)) return false;
+        if (Math.abs(piece) == 1 && isNiFu(board, x, side)) return false;
 
         // 打ち歩詰め
-        if (isUchiFuZume(board, x, y, side)) return false;
+        if (Math.abs(piece) == 1 && isUchiFuZume(board, x, y, side)) return false;
 
         // 桂馬の打ち制限
-        if (piece == Piece.KEI_SENTE || piece == Piece.KEI_GOTE) {
+        if (Math.abs(piece) == 3) {
             if ((side == PlayerSide.SENTE && y <= 1) || (side == PlayerSide.GOTE && y >= 7)) return false;
         }
 
         // 歩・香の最下段制限
-        if (piece == Piece.FU_SENTE || piece == Piece.FU_GOTE || piece == Piece.KYO_SENTE || piece == Piece.KYO_GOTE) {
+        if (Math.abs(piece) == 1 || Math.abs(piece) == 2) {
             if ((side == PlayerSide.SENTE && y == 0) || (side == PlayerSide.GOTE && y == 8)) return false;
         }
 

--- a/src/main/java/com/souma1024/shogiv2/domain/ShogiEngine.java
+++ b/src/main/java/com/souma1024/shogiv2/domain/ShogiEngine.java
@@ -103,6 +103,12 @@ public class ShogiEngine {
             if (hand[actualPiece] == 0) {
                 System.out.println("❌ 持ち駒に指定された駒がありません");
                 return new ApplyMoveResult(false, null);
+            } else {
+                hand[actualPiece]--;
+                capturedPiece = new CapturedPiece();
+                capturedPiece.setOwner(move.getPlayerId());
+                capturedPiece.setPiece(actualPiece);
+                capturedPiece.setCount(hand[actualPiece]);
             }
         } else {
             int captured = getPieceAt(to[0], to[1]);
@@ -112,7 +118,7 @@ public class ShogiEngine {
 
                 capturedPiece = new CapturedPiece();
                 capturedPiece.setOwner(move.getPlayerId());
-                capturedPiece.setPiece(captured);
+                capturedPiece.setPiece(-1 * captured);
                 capturedPiece.setCount(capturedPieces.get(move.getPlayerId())[actualPiece]);
             }
 

--- a/src/main/resources/static/js/game/boardRenderer.js
+++ b/src/main/resources/static/js/game/boardRenderer.js
@@ -16,19 +16,19 @@ export function drawBoard(board, isSente) {
     }
 }
 
-export function drawCell(from, to, piece) {
-    const [toX, toY] = to;
+export function drawCell(res) {
+    const [toX, toY] = res.to;
 
-    if (from !== null) {
-        const [fromX, fromY] = from;
+    if (res.from !== null) {
+        const [fromX, fromY] = res.from;
         const fromCell = document.getElementById(`cell-${fromX}-${fromY}`);
         if (fromCell) fromCell.innerHTML = "";
     }
 
-    if (from === null) {
+    if (res.from === null) {
         // 打ち駒のときは、元が持ち駒フィールド
-        const kind = Math.abs(piece);
-        const capturedCellId = `capturedCell-${state.playerId}-${kind}`;
+        const kind = Math.abs(res.piece);
+        const capturedCellId = `capturedCell-${res.captured.owner}-${kind}`;
         const cell = document.getElementById(capturedCellId);
         if (cell) {
             cell.innerHTML = ""; // 手動で消す
@@ -73,10 +73,10 @@ export function initBoardClickHandlers() {
 }
 
 export function applyCapturedPieces(captured) {
-    if (!captured) return;
+    if (!captured || captured.count == 0) return;
     const { owner, piece, count } = captured;
     const kind = Math.abs(piece);
-    const capturedPiece = piece * -1;
+    const capturedPiece = piece;
     const capturedCellId = `capturedCell-${owner}-${kind}`;
     const cell = document.getElementById(capturedCellId);
     if (!cell) return;

--- a/src/main/resources/static/js/game/socketHandler.js
+++ b/src/main/resources/static/js/game/socketHandler.js
@@ -49,7 +49,7 @@ function handleMoveResponse(res) {
 
     // update state
     applyMoveToBoard(res.from, res.to, res.piece, res.promotion);
-    drawCell(res.from, res.to, res.piece);
+    drawCell(res);
     resetSelectionAndHighlight();
 }
 


### PR DESCRIPTION
持ち駒を打つとき、自フィールドの持ち駒が消えないという現象が起きていたので、move_responseの構造を少し変えて対処しました。